### PR TITLE
ConceptInsights.semanticSearch ids as an array of strings instead of a JSON blob

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# http://editorconfig.org/
+
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+# break out .yml settings even though they match, because you always want .yml on soaced indentation - it can choke on tabs
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/examples/concept_insights.v1.js
+++ b/examples/concept_insights.v1.js
@@ -8,6 +8,10 @@ var concept_insights = watson.concept_insights({
   version: 'v1'
 });
 
+///////////////////
+// Annotate text //
+///////////////////
+
 var params = {
   user: 'wikipedia',
   graph: 'en-20120601',
@@ -20,4 +24,28 @@ concept_insights.annotateText(params, function(err, res) {
     console.log(err);
   else
     console.log(JSON.stringify(res, null, 2));
+});
+
+
+/////////////////////
+// Semantic Search //
+/////////////////////
+
+var payload = {
+  func: 'semanticSearch',
+  ids: [
+    '/graph/wikipedia/en-20120601/Software_development_process',
+    '/graph/wikipedia/en-20120601/Programming_tool'
+  ],
+  corpus: 'ibmresearcher',
+  user: 'public',
+  limit: 5
+
+};
+
+concept_insights.semanticSearch(payload, function(error, results) {
+  if (error)
+    console.log(error);
+  else
+    console.log(JSON.stringify(results, null, 2));
 });

--- a/services/concept_insights/v1.js
+++ b/services/concept_insights/v1.js
@@ -284,6 +284,22 @@ ConceptInsights.prototype.labelSearch = function(params, callback) {
  */
 ConceptInsights.prototype.semanticSearch = function(params, callback) {
   params = params || {};
+
+  // Initially, we expected the user to supply JSON.stringify'd ids. Now we expect an array of strings that we'll JSON.stringify our self.
+  // We still support the old version for backwards compatibility, BUT we don't want to accept any old string, only a valid JSON array, so we parse and check it to be sure.
+  if (!Array.isArray(params.ids)) {
+    try {
+      params.ids = JSON.parse(params.ids);
+    } catch (ex) {
+      // if it wasn't valid JSON, then it still won't be an array and we'll throw an error when we check that in a couple of lines
+    }
+    if (!Array.isArray(params.ids)) {
+      return process.nextTick(callback.bind(null, new Error("Invalid or missing required parameters: the ids param be an array of strings")));
+    }
+  }
+
+  params.ids = JSON.stringify(params.ids);
+
   var parameters = {
     options: {
       url: '/v1/searchable/{user}/{corpus}',

--- a/test/test.concept_insights.v1.js
+++ b/test/test.concept_insights.v1.js
@@ -438,15 +438,51 @@ describe('concept_insights', function() {
             'timestamp': '2014-03-31T20:04:57.74-04:00'
           };
 
+        // format the service_request params the way the actual API expects
+        service_request.ids = JSON.stringify(service_request.ids);
+
         nock(service.url).persist()
         .get(path, service_request)
         .reply(200, service_response);
 
+
         var req = concept_insights.semanticSearch(payload, noop);
-        assert.equal(req.uri.href, service.url + path + '?' +
-          qs.stringify(service_request));
+        var actual = req.uri.href,
+            expected = service.url + path + '?' + qs.stringify(service_request);
+        console.log(actual, expected);
+        assert.equal(actual, expected);
 
         assert.equal(req.method, 'GET');
+    });
+
+    it('should still allow pre-stringified ids for backwards compatibility', function() {
+      var path = '/v1/searchable/public/test',
+        ids = ['bar', 'foo'],
+        payload = {user:'public', corpus:'test', ids: JSON.stringify(ids)},
+        service_request = {func: 'semanticSearch', ids:payload.ids},
+        service_response = {
+          'stage': 'ready',
+          'status': 'done',
+          'timestamp': '2014-03-31T20:04:57.74-04:00'
+        };
+
+      // format the service_request params the way the actual API expects
+      service_request.ids = JSON.stringify(ids);
+
+      nock(service.url).persist()
+        .get(path, service_request)
+        .reply(200, service_response);
+
+
+      var req = concept_insights.semanticSearch(payload, noop);
+      var actual = req.uri.href,
+        expected = service.url + path + '?' + qs.stringify(service_request);
+      assert.equal(actual, expected);
+      assert.equal(req.method, 'GET');
+    });
+
+    it('should not accept a single string for the ids', function() {
+      concept_insights.semanticSearch({user:'public', corpus:'test', ids: 'foo'}, missingParameter);
     });
   });
 


### PR DESCRIPTION
This should fix #10 and also be a good pattern to follow for other APIs that expect JSON blobs in the HTTP request.