### PR TITLE
Add authorization service wrapper

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -92,7 +92,8 @@ var watson = {};
   'concept_insights',
   'tradeoff_analytics',
   'personality_insights',
-  'natural_language_classifier'
+  'natural_language_classifier',
+  'authorization'
 
 ].forEach(function(api) {
   watson[api] = createServiceAPI(api);

--- a/services/authorization/v1.js
+++ b/services/authorization/v1.js
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2015 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+var pick           = require('object.pick');
+var extend         = require('extend');
+var requestFactory = require('../../lib/requestwrapper');
+
+function Authorization(options) {
+  // Default URL
+  var serviceDefaults = {
+    url: 'https://stream.watsonplatform.net/authorization/api'
+  };
+
+  // Replace default options with user provided
+  this._options = extend(serviceDefaults, options);
+}
+
+/**
+ * Get authorization token based on resource query string param
+ */
+Authorization.prototype.getToken = function(params, callback) {
+  if (!params.url){
+    callback(new Error('Missing required parameters: url'));
+    return;
+  }
+
+  var parameters = {
+    options: {
+      method: 'GET',
+      url: '/v1/token',
+      qs: pick(params, ['url'])
+    },
+    defaultOptions: this._options
+  };
+  return requestFactory(parameters, callback);
+};
+
+
+module.exports = Authorization;

--- a/test/test.authorization.v1.js
+++ b/test/test.authorization.v1.js
@@ -1,0 +1,66 @@
+'use strict';
+
+var assert = require('assert');
+var watson = require('../lib/index');
+var nock   = require('nock');
+var qs     = require('querystring');
+var pick   = require('object.pick');
+var omit   = require('object.omit');
+
+describe('authorization', function() {
+
+  var noop = function() {};
+
+  // Test params
+  var service_request = {
+    url: 'http://ibm.com:80/text-to-speech-beta/api'
+  };
+  var service = {
+    username: 'batman',
+    password: 'bruce-wayne',
+    url: 'http://ibm.com:80',
+    version: 'v1'
+  };
+  var token_path = '/v1/token';
+  var token_request = token_path + '?' + qs.stringify(service_request);
+
+  var mock_token = 'token';
+
+  before(function() {
+    nock.disableNetConnect();
+    nock(service.url)
+      .persist()
+      .get(token_path)
+      .reply(200, mock_token);
+  });
+
+  after(function() {
+    nock.cleanAll();
+  });
+
+  var authorization = watson.authorization(service);
+
+  var missingParameter = function(err) {
+    assert.ok((err instanceof Error) && /required parameters/.test(err));
+  };
+
+  describe('getToken()', function(){
+
+    it('should check for missing url param', function() {
+      var params = {
+        noturl: service_request.url
+      };
+      authorization.getToken(params, missingParameter);
+    });
+
+    it('should generate a valid token payload', function() {
+      var checkToken = function(err, res) {
+        assert.equal(res, mock_token);
+      };
+
+      authorization.getToken({url: 'http://ibm.com/myservice/myresource'}, checkToken);
+    });
+
+  });
+
+});


### PR DESCRIPTION
This is a PR for the new authorization service.  The Authorization service is structures like the other services, but only has a single function that sits on its prototype: getToken

This function takes a options object with a required 'url' property, since sending the URL of the intended resource for the Authorization service is required (tokens carry permissions that are constrained by path).

The other possibility is instead of passing in the URL, we could pass in the service that the token will be used with, which "knows" what the URL is.  Would this be a better approach?

I'm open to suggestions on improvements, and will check back by in a few hours (I need to spend a block of time now finishing up additional TTS demo app features).