### PR TITLE
fixed the documentation for the  authorization api

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ var params = {
   url: 'https://stream.watsonplatform.net/text-to-speech/api'
 };
 
-authorization.getToken(params, function (token) {
+authorization.getToken(params, function (err, token) {
   if (!token) {
     console.log('error:', err);
   } else {


### PR DESCRIPTION
The callback for the authorization api getToken function takes the arguments (err, token), not just (token).  It's possible that the documentation should be changed further to reflect that so that the callback looks like

function (err, token) {
    if (err) {
        console.log('error:  ' + err);
    } else {
        //use token here
    }
}

