### PR TITLE
adding Tone Analyzer v2

### DIFF
--- a/services/tone_analyzer/v2.js
+++ b/services/tone_analyzer/v2.js
@@ -96,11 +96,7 @@ ToneAnalyzer.prototype.synonym = function(params, callback) {
       qs: params,
       json: true
     },
-    defaultOptions: extend(this._options, {
-      headers: {
-        'accept':'application/json'
-      }
-    })
+    defaultOptions: extend(this._options, {})
   };
 
   return requestFactory(parameters, callback);
@@ -121,13 +117,10 @@ ToneAnalyzer.prototype.scorecards = function(params, callback) {
   var parameters = {
     options: {
       url: '/v2/scorecards',
-      method: 'GET'
+      method: 'GET',
+      json: true
     },
-    defaultOptions: extend(this._options, {
-      headers: {
-        'accept':'application/json'
-      }
-    })
+    defaultOptions: extend(this._options, {})
   };
 
   return requestFactory(parameters, callback);

--- a/services/tone_analyzer/v2.js
+++ b/services/tone_analyzer/v2.js
@@ -1,0 +1,136 @@
+/**
+ * Copyright 2015 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+var extend         = require('extend');
+var requestFactory = require('../../lib/requestwrapper');
+
+function ToneAnalyzer(options) {
+  // Default URL
+  var defaultOptions = {
+    url: 'https://gateway.watsonplatform.net/tone-analyzer-experimental/api'
+  };
+
+  // Replace default options with user provided
+  this._options = extend(defaultOptions, options);
+}
+
+/**
+ * Main API call. Returns the different tone dimensions of a text.
+ *
+ * @param params: An object with a string 'text' element. This is the
+ * only field used. By this API call
+ *
+ * @return upon success, the callback function is called with an object
+ * containing the different tones (emotion, writing and social), traits
+ * and the evidence words found in the text.
+ *
+ * @see the API docs for a the full documentation.
+ *
+ */
+ToneAnalyzer.prototype.tone = function(params, callback) {
+  if (!params || !params.text){
+    callback(new Error('Missing required parameters: text'));
+    return;
+  }
+
+  var parameters = {
+    options: {
+      url: '/v2/tone',
+      method: 'POST',
+      body: params.text
+    },
+    defaultOptions: extend(this._options, {
+      headers: {
+        'accept':'application/json',
+        'content-type': 'text/plain'
+      }
+    })
+  };
+
+  return requestFactory(parameters, callback);
+};
+
+/**
+ * Returns related words for a given word (or set of words).
+ *
+ * @param params: An object to build the query string. It normally contains
+ * a property "word", the term to look up.
+ * Alternatively, one can specify a "context" (part of a phrase) and an
+ * "index" (of the word to lookup, within "context").
+ * A 'limit' parameter is also accepted to limit the number of related 
+ * words suggested.
+ *
+ * @return upon success, the callback function is called with an object
+ * containing related words to the ones given. Each word comes with
+ * the semantic type and the meaning and sense of the root word, and
+ * a weight associated to a trait. Positive weights would 'level up'
+ * that particular tone, while negative weights would level it down.
+ *
+ * For example, if one wants to sound less "angry" on a message, the
+ * suggestions with negative correlation with "Anger" (Emotion Tone)
+ * could be replaced in the txt.
+ *
+ * @see the API docs for a the full documentation.
+ *
+ */
+ToneAnalyzer.prototype.synonym = function(params, callback) {
+  var parameters = {
+    options: {
+      url: '/v2/synonym',
+      method: 'GET',
+      qs: params,
+      json: true
+    },
+    defaultOptions: extend(this._options, {
+      headers: {
+        'accept':'application/json'
+      }
+    })
+  };
+
+  return requestFactory(parameters, callback);
+};
+
+
+
+/**
+ * Returns the different scorecards implemented by the service.
+ * This is an array of objects with a "name" and "description" properties.
+ * 
+ * As a first version, only a "business email" scorecard is implemented.
+ *
+ * @see the API docs for a the full documentation.
+ *
+ */
+ToneAnalyzer.prototype.scorecards = function(params, callback) {
+  var parameters = {
+    options: {
+      url: '/v2/scorecards',
+      method: 'GET'
+    },
+    defaultOptions: extend(this._options, {
+      headers: {
+        'accept':'application/json'
+      }
+    })
+  };
+
+  return requestFactory(parameters, callback);
+};
+
+module.exports = ToneAnalyzer;

--- a/test/test.tone_analyzer.v2.js
+++ b/test/test.tone_analyzer.v2.js
@@ -3,8 +3,9 @@
 var assert = require('assert');
 var watson = require('../lib/index');
 var nock   = require('nock');
+var qs = require('qs');
 
-describe('tone_analyzer.v1', function() {
+describe('tone_analyzer.v2', function() {
 
   var noop = function() {};
 
@@ -12,22 +13,21 @@ describe('tone_analyzer.v1', function() {
     text: 'IBM Watson Developer Cloud'
   };
   var synonym_request = {
-	  'words': ['greece'],
-	  'limit': 4
+	  'word': 'product'
   };
   var tone_response = {
     tree: {}
   };
   var synonym_response = [ { headword: 'x' } ];
 
-  var tone_path = '/v1/tone',
-	synonym_path = '/v1/synonym';
+  var tone_path = '/v2/tone',
+	synonym_path = '/v2/synonym';
 
   var service = {
     username: 'batman',
     password: 'bruce-wayne',
     url: 'http://ibm.com:86',
-    version: 'v1'
+    version: 'v2'
   };
 
   before(function() {
@@ -36,7 +36,7 @@ describe('tone_analyzer.v1', function() {
       .persist()
       .post(tone_path, tone_request.text)
       .reply(200, tone_response)
-      .post(synonym_path, synonym_request)
+      .get(synonym_path + '?' + qs.stringify(synonym_request))
       .reply(200, synonym_response);
   });
 
@@ -85,13 +85,12 @@ describe('tone_analyzer.v1', function() {
     tone_analyzer.synonym(undefined, missingParameter);
   });
 
-  it('synonym API should generate a valid payload with content', function() {
+  it('synonym API should generate a valid payload with content', function() {      
       var req = tone_analyzer.synonym(synonym_request, noop);
-      var body = new Buffer(req.body).toString('ascii');
-      assert.equal(req.uri.href, service.url + synonym_path);
-      assert.equal(body, JSON.stringify(synonym_request));
-      assert.equal(req.method, 'POST');
-      assert.equal(req.headers['content-type'], 'application/json');
+      var myquery = qs.stringify(synonym_request);
+      assert.equal(req.uri.href, service.url + synonym_path + '?' + myquery);
+      assert.equal(req.uri.query, myquery);
+      assert.equal(req.method, 'GET');
   });
   it('synonym API should format the response', function(done) {
     tone_analyzer.synonym(synonym_request, function(err, response) {


### PR DESCRIPTION
Adds a new V2 api wrapper for Tone Analyzer. The Tone Analyzer API is changing (about to be published), mainly changing /synonym from POST to GET. 

v1 wrapper is unchanged. v2 wrapper is added. test cases for v2 are also added.