### PR TITLE
fixed Tone Analyzer v2 synonyms API endpoint

### DIFF
--- a/services/tone_analyzer/v2.js
+++ b/services/tone_analyzer/v2.js
@@ -91,7 +91,7 @@ ToneAnalyzer.prototype.tone = function(params, callback) {
 ToneAnalyzer.prototype.synonym = function(params, callback) {
   var parameters = {
     options: {
-      url: '/v2/synonym',
+      url: '/v2/synonyms',
       method: 'GET',
       qs: params,
       json: true

--- a/test/test.tone_analyzer.v2.js
+++ b/test/test.tone_analyzer.v2.js
@@ -21,7 +21,7 @@ describe('tone_analyzer.v2', function() {
   var synonym_response = [ { headword: 'x' } ];
 
   var tone_path = '/v2/tone',
-	synonym_path = '/v2/synonym';
+	synonym_path = '/v2/synonyms';
 
   var service = {
     username: 'batman',


### PR DESCRIPTION
Fix to initial version of v2.js module: api endpoint changed to "synonyms"