### PR TITLE
Added formattedAnswer parameter to question body options

### DIFF
--- a/services/question_and_answer/v1.js
+++ b/services/question_and_answer/v1.js
@@ -23,9 +23,10 @@ var requestFactory = require('../../lib/requestwrapper');
 function toQuestion(params) {
   return {
     evidenceRequest: {
-      items: params.items || 5 // the number of anwers, 5 by default
+      items: params.items || 5 // the number of answers, 5 by default
     },
-    questionText: params.text
+    questionText: params.text,
+    formattedAnswer: (params.formattedAnswer) ? params.formattedAnswer : false
   };
 };
 


### PR DESCRIPTION
This fixes issue 112 (https://github.com/watson-developer-cloud/nodejs-wrapper/issues/112), which addresses the fact that you could previously not add the formattedAnswer parameter to the Q&A invocation.